### PR TITLE
add mvp of spelling sphinx extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ Happy coding!
 * `jupyter-book build .` from root
 * `python -m http.server --directory _build/html/`
 
+### Spell check
+
+* `pip install sphinxcontrib-spelling`
+* `jupyter-book config sphinx` generates `conf.py`
+* Add the following lines to `conf.py`:
+```
+spelling_ignore_pypi_package_names=True
+spelling_word_list_filename = 'spelling_correctwords.txt'
+```
+* `sphinx-build -b spelling . ./_build` from root (this is in place of `jupyter-book build .`
+
 ## Deploy
 [link](https://jupyterbook.org/start/publish.html#publish-your-book-online-with-github-pages)
 1. Build book

--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,11 @@ html:
   use_repository_button: true
   favicon : "favicon.ico"
 
+# Include sphinx extensions
+sphinx:
+  extra_extensions:
+  - "sphinxcontrib.spelling"
+
 # Surpress binder link since it doesn't work
 launch_buttons:
   binderhub_url: ""

--- a/spelling_correctwords.txt
+++ b/spelling_correctwords.txt
@@ -1,0 +1,10 @@
+dataframe
+Dataframes
+epsg
+crs
+legos
+groupby
+nan
+NaN
+Cawker
+Filepaths


### PR DESCRIPTION
## What has been built?

This PR adds MVP-level functionality to use the [sphinx spelling](https://sphinxcontrib-spelling.readthedocs.io/en/latest/) extension as a spell checker.

## How was it done?

* `sphinxcontrib.spelling` was added as an extension in `_conf.yml`
* documentation for how to run the spell check were added to the README
* a sheet called `spelling_correctwords.txt` was added to the root that contains words that should be skipped by spell check


## How can it be tested?

Run the instructions below (copied from the README):
* `pip install sphinxcontrib-spelling` -- this installs the proper module in the environment
* `jupyter-book config sphinx` generates `conf.py` -- this creates a file (`conf.py`) that will allow us to bypass `jupyter-book build .` and run the sphinx build command directly
* Add the following lines to `conf.py`: -- these are our custom configuration settings for the module
```
spelling_ignore_pypi_package_names=True
spelling_word_list_filename = 'spelling_correctwords.txt'
```
* `sphinx-build -b spelling . ./_build` from root (this is in place of `jupyter-book build .` -- This builds the book while checking for spelling. The output of this build includes locations of spelling errors detected in the text